### PR TITLE
Add region overrides for Sevii 4567 pokemon + Unown

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -12219,10 +12219,20 @@ const pokemonRegionOverride = {
     ...Object.fromEntries(
         pokemonList.filter(p => Math.floor(p.id) == 25 && p.id > 25).map(p => [p.name, GameConstants.Region.alola])
     ),
-    'Pikachu (Clone)': GameConstants.Region.kanto,
-    'Pinkan Pikachu': GameConstants.Region.kalos,
-    'Detective Pikachu': GameConstants.Region.kanto,
+    'Detective Pikachu': GameConstants.Region.kalos,
+    'Detective Raichu': GameConstants.Region.kalos,
     'Pikachu (World Cap)': GameConstants.Region.galar,
+
+    // Valencian and Pinkan
+    ...Object.fromEntries(
+        pokemonList.filter(p => p.name.startsWith('Pinkan ') || p.name.startsWith('Valencian '))
+            .map(p => [p.name, GameConstants.Region.hoenn])
+    ),
+    'Pink Butterfree': GameConstants.Region.hoenn,
+    "Ash's Butterfree": GameConstants.Region.hoenn,
+    'Pinkan Pikachu': GameConstants.Region.kalos,
+    'Crystal Onix': GameConstants.Region.hoenn,
+    'Crystal Steelix': GameConstants.Region.hoenn,
 
     // Mega and Primal
     ...Object.fromEntries(
@@ -12236,6 +12246,9 @@ const pokemonRegionOverride = {
             .map(p => [p.name, GameConstants.Region.galar])
     ),
 
+    'Unown (E)': GameConstants.Region.sinnoh,
+    'Unown (!)': GameConstants.Region.hoenn,
+    'Unown (?)': GameConstants.Region.hoenn,
     'XD001': GameConstants.Region.hoenn,
     'Hoppip (Chimecho)': GameConstants.Region.hoenn,
     'Meltan': GameConstants.Region.alola,

--- a/scripts/data.js
+++ b/scripts/data.js
@@ -88,10 +88,19 @@ const pokemonRegionOverride = {
     ...Object.fromEntries(
         pokemonList.filter(p => Math.floor(p.id) == 25 && p.id > 25).map(p => [p.name, GameConstants.Region.alola])
     ),
-    'Pikachu (Clone)': GameConstants.Region.kanto,
-    'Pinkan Pikachu': GameConstants.Region.kalos,
     'Detective Pikachu': GameConstants.Region.kanto,
     'Pikachu (World Cap)': GameConstants.Region.galar,
+
+    // Valencian and Pinkan
+    ...Object.fromEntries(
+        pokemonList.filter(p => p.name.startsWith('Pinkan ') || p.name.startsWith('Valencian '))
+            .map(p => [p.name, GameConstants.Region.hoenn])
+    ),
+    'Pink Butterfree': GameConstants.Region.hoenn,
+    "Ash's Butterfree": GameConstants.Region.hoenn,
+    'Pinkan Pikachu': GameConstants.Region.kalos,
+    'Crystal Onix': GameConstants.Region.hoenn,
+    'Crystal Steelix': GameConstants.Region.hoenn,
 
     // Mega and Primal
     ...Object.fromEntries(
@@ -105,6 +114,9 @@ const pokemonRegionOverride = {
             .map(p => [p.name, GameConstants.Region.galar])
     ),
 
+    'Unown (E)': GameConstants.Region.sinnoh,
+    'Unown (!)': GameConstants.Region.hoenn,
+    'Unown (?)': GameConstants.Region.hoenn,
     'XD001': GameConstants.Region.hoenn,
     'Hoppip (Chimecho)': GameConstants.Region.hoenn,
     'Meltan': GameConstants.Region.alola,

--- a/scripts/data.js
+++ b/scripts/data.js
@@ -88,7 +88,8 @@ const pokemonRegionOverride = {
     ...Object.fromEntries(
         pokemonList.filter(p => Math.floor(p.id) == 25 && p.id > 25).map(p => [p.name, GameConstants.Region.alola])
     ),
-    'Detective Pikachu': GameConstants.Region.kanto,
+    'Detective Pikachu': GameConstants.Region.kalos,
+    'Detective Raichu': GameConstants.Region.kalos,
     'Pikachu (World Cap)': GameConstants.Region.galar,
 
     // Valencian and Pinkan


### PR DESCRIPTION
Makes it so any Pokemon only obtainable in Sevii 4567 count as Hoenn region mons.
Also makes it so the exclusive Unown E's region is Sinnoh and both Unown ? and !'s region is Hoenn.