### PR TITLE
Make the note for total vitamins needed more clear

### DIFF
--- a/components/vitaminTracker.html
+++ b/components/vitaminTracker.html
@@ -62,7 +62,7 @@
                 <div class="text-end small mt-2">* Load a save file to view the vitamins your Pokémon currently have</div>
                 <!-- /ko -->
                 <!-- ko if: SaveData.isLoaded -->
-                <div class="text-end small mt-2">* Above totals do not include vitamins you have already purchased</div>
+                <div class="text-end small mt-2">* Above totals does not consider whether vitamins have been purchased or not</div>
                 <!-- /ko -->
             </div>
         </div>


### PR DESCRIPTION
The note as it is is misleading, as it makes it sound like the number does not include vitamins which have been purchased, but it actually means that the number does not care if the vitamins have been purchased or not. 

For example, if it says you need 100 carbos, and you purchase 10, then it seems like the number would become 90 since it does not include the 10 have been purchased. But the number will actually stay 100.

I think the totals would be improved if they actually did work the way the note makes it seem, since then it would tell you how many more you need to purchase rather than just telling you a number which you then need to figure out how to turn into practical information. I'll look into making a future PR that does this, but I'm not that great at JS so we'll see what happens.